### PR TITLE
Added an optional callback for when the scroll animation is finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ const options = {
 
   // should animated scroll be canceled on user scroll/keypress
   // if set to "false" user input will be disabled until animated scroll is complete
-  cancelOnUserAction: true
+  cancelOnUserAction: true,
+
+  // function that will be executed when the scroll animation is finished
+  onComplete: function() {}
 };
 
 const desiredOffset = 1000;

--- a/animated-scroll-to.js
+++ b/animated-scroll-to.js
@@ -12,6 +12,7 @@
       maxDuration: 1500,
       cancelOnUserAction: true,
       element: window,
+      onComplete: undefined,
     };
 
     var options = {};
@@ -121,6 +122,11 @@
           window.removeEventListener('keydown', handleUserEvent);
         } else {
           window.removeEventListener('scroll', handleUserEvent);
+        }
+
+        // Animation is complete, execute callback if there is any
+        if (options.onComplete && typeof options.onComplete === 'function') {
+          options.onComplete()
         }
       }
     };


### PR DESCRIPTION
I was missing the option to have a callback for when the scrolling animation is finished. It seemed like a small adjustment to me, so I added it. I hope it didn't miss anything crucial. Would be nice if this can be merged and be useful for others :)