### PR TITLE
Bugfix - incorrect desiredOffset value

### DIFF
--- a/animated-scroll-to.js
+++ b/animated-scroll-to.js
@@ -7,8 +7,13 @@
     var userOptions = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     if (desiredOffset instanceof HTMLElement) {
-      var scrollTop = window.scrollY || document.documentElement.scrollTop;
-      desiredOffset = scrollTop + desiredOffset.getBoundingClientRect().top;
+      if (userOptions.element && userOptions.element instanceof HTMLElement) {
+        desiredOffset = (desiredOffset.getBoundingClientRect().top + userOptions.element.scrollTop)
+          - userOptions.element.getBoundingClientRect().top;
+      } else {
+        var scrollTop = window.scrollY || document.documentElement.scrollTop;
+        desiredOffset = scrollTop + desiredOffset.getBoundingClientRect().top;
+      }
     }
 
     var defaultOptions = {


### PR DESCRIPTION
Fixed bug where both desiredOffset is an HTMLElement and userOptions is set and is an HTMLElement. Bug was that if partially scrolled through the element, the desiredOffset would produce incorrect values and cause the scrolling to "bounce" and not stay in the location where it ought to have scrolled to.